### PR TITLE
Fix significant eigenvalue typo

### DIFF
--- a/notes/eigen.md
+++ b/notes/eigen.md
@@ -388,12 +388,12 @@ $$ \mathbf{e}_{k+1} \approx \frac{|\lambda_\text{closest} - \sigma|}{|\lambda_\t
 | Shifted Inverse Power Method   | $$(\mathbf{A} - \sigma \mathbf{I}) \boldsymbol{x}_{k+1} = \boldsymbol{x}_{k}$$          | $$n^{3} + kn^2$$ | $$\left\|\frac{\lambda_c-\sigma}{\lambda_{c2}-\sigma}\right\|$$ |
 
 
-$$\lambda_1$$: largest eigenvector (in magnitude) \\
-$$\lambda_2$$: second largest eigenvector (in magnitude) \\
-$$\lambda_n$$: smallest eigenvector (in magnitude) \\
-$$\lambda_{n-1}$$: second smallest eigenvector (in magnitude) \\
-$$\lambda_c$$: closest eigenvector to $$\sigma$$ \\
-$$\lambda_{c2}$$: second closest eigenvector to $$\sigma$$
+$$\lambda_1$$: largest eigenvalue (in magnitude) \\
+$$\lambda_2$$: second largest eigenvalue (in magnitude) \\
+$$\lambda_n$$: smallest eigenvalue (in magnitude) \\
+$$\lambda_{n-1}$$: second smallest eigenvalue (in magnitude) \\
+$$\lambda_c$$: closest eigenvalue to $$\sigma$$ \\
+$$\lambda_{c2}$$: second closest eigenvalue to $$\sigma$$
 
 ## Orthogonal Matrices
 

--- a/notes/markov.md
+++ b/notes/markov.md
@@ -194,7 +194,7 @@ A weakpoint of this naive implementation of Page Rank is that a unique solution 
 
 <div>\[{\bf{M}} = d{\bf{A}} + \frac{1-d}{n}\bf{1} \]</div>
 
-We introduce a constant, or damping factor, <span>\\(d\\)</span> in order to model the random jump. Let <span>\\(n\\)</span> by the number of nodes in the graph. Here, a surfer clicks on a link on the current page with probability <span>\\(d\\)</span> and opens a random page with probability <span>\\(1-d\\)</span>. This model makes all entries of M greater than zero, and guarantees a unique solution.
+We introduce a constant, or damping factor, <span>\\(d\\)</span> in order to model the random jump. Let <span>\\(n\\)</span> be the number of nodes in the graph. Here, a surfer clicks on a link on the current page with probability <span>\\(d\\)</span> and opens a random page with probability <span>\\(1-d\\)</span>. This model makes all entries of M greater than zero, and guarantees a unique solution.
 
 ## Review Questions
 


### PR DESCRIPTION
Typo where eigenvector is written instead of eigenvalue
Typo in Markov of "Let by" instead of "Let be"